### PR TITLE
Access current apps

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -19,11 +19,16 @@ export default function Edit() {
 	const [apps, setApps] = useState<AppTypes[]>([]);
 	const appsRef = useRef<AppTypes[]>(apps);
 	const [deletedApps, setDeletedApps] = useState<AppTypes[]>([]);
+	const deletedAppsRef = useRef<AppTypes[]>(deletedApps);
 	const [timeouts, setTimeouts] = useState<TimeoutTypes[]>([]);
 
 	useEffect(() => {
 		appsRef.current = apps;
 	}, [apps]);
+
+	useEffect(() => {
+		deletedAppsRef.current = deletedApps;
+	}, [deletedApps]);
 
 	function addApp(app: AppTypes) {
 		const updatedApps = [...apps];
@@ -45,7 +50,7 @@ export default function Edit() {
 		function delayedDelete() {
 			if (!appsRef.current[appIndex].active) {
 				setApps(purgeApp(appIndex, appsRef.current));
-				setDeletedApps(purgeDeletedApp(id, deletedApps));
+				setDeletedApps(purgeDeletedApp(id, deletedAppsRef.current));
 			}
 		}
 

--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import AppPage from '../apppage';
 import Modal from './modal';
@@ -17,8 +17,13 @@ import { TimeoutTypes, addTimeout, removeTimeout } from './timeout';
 export default function Edit() {
 	const [showModal, setShowModal] = useState(false);
 	const [apps, setApps] = useState<AppTypes[]>([]);
+	const appsRef = useRef<AppTypes[]>(apps);
 	const [deletedApps, setDeletedApps] = useState<AppTypes[]>([]);
 	const [timeouts, setTimeouts] = useState<TimeoutTypes[]>([]);
+
+	useEffect(() => {
+		appsRef.current = apps;
+	}, [apps]);
 
 	function addApp(app: AppTypes) {
 		const updatedApps = [...apps];
@@ -38,8 +43,8 @@ export default function Edit() {
 		const deletedApp = apps.find((app: AppTypes) => app.id === id);
 
 		function delayedDelete() {
-			if (!apps[appIndex].active) {
-				setApps(purgeApp(appIndex, apps));
+			if (!appsRef.current[appIndex].active) {
+				setApps(purgeApp(appIndex, appsRef.current));
 				setDeletedApps(purgeDeletedApp(id, deletedApps));
 			}
 		}


### PR DESCRIPTION
Fixes an issue where apps added while the undo timeout was running would be removed once the timeout completes.

This was because the delayedDelete function that ran after the timeout completed only had access to an older version of state.

Using the useRef hook, and updating the ref.current each time state updated with useEffect allows delayedDelete to have access to the most current version of state.