### PR TITLE
Get new index upon delayedDelete

### DIFF
--- a/src/app/edit/page.tsx
+++ b/src/app/edit/page.tsx
@@ -48,8 +48,10 @@ export default function Edit() {
 		const deletedApp = apps.find((app: AppTypes) => app.id === id);
 
 		function delayedDelete() {
-			if (!appsRef.current[appIndex].active) {
-				setApps(purgeApp(appIndex, appsRef.current));
+			const index = appsRef.current.findIndex((app) => app.id === id);
+
+			if (!appsRef.current[index].active) {
+				setApps(purgeApp(index, appsRef.current));
 				setDeletedApps(purgeDeletedApp(id, deletedAppsRef.current));
 			}
 		}


### PR DESCRIPTION
When delayedDelete ran, we were using an older version of the app index within the context of the array _prior_ to other apps getting deleted or added. Therefore, that index could no longer exist once delayedDelete ran. 

By finding an updated index immediately before purging the app, this fixed the issue. 